### PR TITLE
Allow to install this package without bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,11 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "grunt test"
+  },
+  "dependencies": {
+    "angular": "~1.2.15",
+    "angular-sanitize": "~1.2.15"
   },
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
When installing project on some production environment that doesn't have bower installed globally, installation fails because it cannot install bower dependencies. So I just removed installation of dependencies via bower and added these dependencies to package.json, so NPM can handle them.